### PR TITLE
feature(Commenting): Allow commenting via CLI $EDITOR (only CLI for now)

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,5 +2,5 @@ version: 1.0
 shards:
   ncurses:
     github: geolessel/ncurses.cr
-    commit: 2b1d18eb2f725ae13e53cae7eb1e601c8c1b1f34
+    commit: b7bbc1762fcf67b08da02113709c4002ca86f17f
 

--- a/shard.yml
+++ b/shard.yml
@@ -11,7 +11,7 @@ targets:
 dependencies:
   ncurses:
     github: geolessel/ncurses.cr
-    branch: more-ncurses
+    branch: clear-erase
 
 crystal: 0.26.0
 

--- a/src/api.cr
+++ b/src/api.cr
@@ -13,10 +13,10 @@ class API
     json
   end
 
-  def self.post(path : String, params : String)
+  def self.post(path : String, params : String = "", form : String | IO | Hash = "")
     url = "#{API_ROOT}/#{path}?#{App.credentials}&#{params}"
     App.log.debug("POSTing URL: #{url}")
-    response = HTTP::Client.post(url)
+    response = HTTP::Client.post(url, form: form)
   end
 
   def self.put(path : String, params : String)

--- a/src/app.cr
+++ b/src/app.cr
@@ -18,6 +18,17 @@ class App
     @@log = Logger.new(File.open("#{CONFIG_DIR}/log.txt", "w"), level: Logger::DEBUG)
   end
 
+  def self.setup_ncurses
+    NCurses.clear
+    NCurses.erase
+    NCurses.start_color
+    # NCurses.use_default_colors
+    NCurses.cbreak # CTRL-C breaks the program
+    NCurses.noecho # Don't print characters as the user types
+    NCurses.curs_set(0) # hide the cursor
+    NCurses.keypad(true) # allows arrow and F# keys
+  end
+
   def self.activate_window(window : Window)
     @@active_window = window
   end
@@ -66,6 +77,19 @@ class App
     Setup.write_config(@@token, @@member_id)
     puts "Done."
     sleep 1
+  end
+
+  def self.comment_temp_file_path
+    "#{CONFIG_DIR}/comment.tmp"
+  end
+
+  def self.reset_screen
+    NCurses.clear
+    NCurses.erase
+    NCurses.curs_set(1)
+    NCurses.curs_set(0)
+    @@windows.each { |w| w.resize }
+    NCurses.refresh
   end
 
   module Colors

--- a/src/card_detail.cr
+++ b/src/card_detail.cr
@@ -78,4 +78,18 @@ class CardDetail
       App.log.debug("failed to move card to list: #{response.inspect}")
     end
   end
+
+  def add_comment
+    File.delete(App.comment_temp_file_path) if File.exists?(App.comment_temp_file_path)
+
+    Process.run(ENV["EDITOR"], args: {App.comment_temp_file_path}, output: STDOUT, input: STDIN, error: STDERR, shell: true)
+
+    App.reset_screen
+
+    unless !File.exists?(App.comment_temp_file_path) || File.empty?(App.comment_temp_file_path)
+      comment_text = File.read(App.comment_temp_file_path)
+      API.post("/cards/#{@id}/actions/comments", form: { "text" => comment_text })
+      fetch
+    end
+  end
 end

--- a/src/details_window.cr
+++ b/src/details_window.cr
@@ -3,6 +3,7 @@ require "./window"
 require "./help_window"
 require "./app"
 require "./card_action_builder"
+require "./api"
 
 class DetailsWindow < Window
   property row : Int32 = 0
@@ -70,6 +71,8 @@ class DetailsWindow < Window
       end
     when NCurses::KeyCode::DOWN, 'j'
       @row += 1
+    when 'c'
+      @card.add_comment
     when 'd'
       @row += 10
     when 'u'
@@ -89,6 +92,8 @@ class DetailsWindow < Window
       end
     when 'o'
       `open #{@card.short_url}`
+    when 'r'
+      reload_card!
     when 'm'
       ListSelectWindow.new(board_id: @card.board_id) do |win|
         win.link_parent(self)
@@ -109,6 +114,7 @@ class DetailsWindow < Window
       HelpWindow.new do |win|
         win.link_parent(self)
         win.add_help(key: "a", description: "Open an attachment in your browser")
+        win.add_help(key: "c", description: "Add a comment to the file via your $EDITOR (CLI only)")
         win.add_help(key: "SPACE", description: "Add yourself as a member of this card")
         win.add_help(key: "shift-l", description: "Add a label to this card")
         win.add_help(key: "m", description: "Move this card to another list")
@@ -124,6 +130,10 @@ class DetailsWindow < Window
 
   def activate!
     super
+    reload_card!
+  end
+
+  def reload_card!
     @card.fetch
   end
 end

--- a/src/popup.cr
+++ b/src/popup.cr
@@ -1,0 +1,56 @@
+require "ncurses"
+require "./app"
+require "./window"
+
+class Popup < Window
+  include Wrap
+
+  property on_close : Proc(Void) = -> {}
+  property text : String = ""
+
+  def initialize(&block)
+    initialize(x: NCurses.maxx / 4, y: NCurses.maxy / 4, height: NCurses.maxy / 2, width: NCurses.maxx / 2) do |win|
+      win.active = true
+      yield win
+    end
+    App.add_window(self)
+    App.activate_window(self)
+  end
+
+  def initialize(x : Int32, y : Int32, height : Int32, width : Int32, &block)
+    initialize(x: x, y: y, height: height, width: width, border: true)
+    yield self
+  end
+
+  def refresh
+    @win.erase
+    @win.border
+    @win.mvaddstr(@title, x: 2, y: 0) if @title
+    @win.refresh
+
+    NCurses::Pad.open(height: 1000, width: @width - 2) do |pad|
+      pad.addstr(wrap(@text, @width - 2))
+      pad.refresh(0, 0, @y+2, @x+2, @height, @width + @x - 2)
+    end
+  end
+
+  def handle_key(key)
+    case key
+    when 'q', 'Q'
+      release
+    else
+      @on_close.call()
+      release
+    end
+  end
+
+  def release
+    parent = @parent
+    if parent
+      App.activate_window(parent)
+    end
+    App.remove_window(self)
+    @win.erase
+    @win.close
+  end
+end

--- a/src/trello.cr
+++ b/src/trello.cr
@@ -9,12 +9,7 @@ module Trello
   def self.start
     LibNCurses.setlocale(0, "") # enable unicode
     NCurses.open do
-      NCurses.start_color
-      # NCurses.use_default_colors
-      NCurses.cbreak # CTRL-C breaks the program
-      NCurses.noecho # Don't print characters as the user types
-      NCurses.curs_set(0) # hide the cursor
-      NCurses.keypad(true) # allows arrow and F# keys
+      App.setup_ncurses
 
       boards = BoardsWindow.new
       boards.activate!


### PR DESCRIPTION
I FIGURED IT OUT! whew.

This finally allows commenting via your preferred `$EDITOR`. This opens the doors to also create cards and potentially edit comments/cards/descriptions/etc.

One of the directions I originally headed was to just read from a tmp file that was written completely outside of `trello` and to put a popup saying that once you pressed `ENTER`, it would read from that file and use that as the comment. I ended up figuring out how to replace the current process with the `$EDITOR`'s and so no longer needed that popup. I've kept the unused `Popup` code in there for now in case I want to use it in the future.

I've opened a PR for the new NCurses library functions here: https://github.com/agatan/ncurses.cr/pull/7. For now, I'm just using my branch directly. We needed `clear` and `erase` to reset the screen once it returns from the `$EDITOR`.

![cli](https://user-images.githubusercontent.com/385726/46381565-afe2cc80-c65b-11e8-98ab-57303be2b246.gif)
