### PR TITLE
feat: Use text templates for situations that call for `$EDITOR`

### DIFF
--- a/src/app.cr
+++ b/src/app.cr
@@ -71,6 +71,7 @@ class App
 
   def self.run_setup
     Setup.make_config_dir
+    Setup.make_templates
     Setup.display_intro_text
     @@token = Setup.get_token
     @@member_id = Setup.fetch_member_id
@@ -111,8 +112,17 @@ class App
   module Setup
     extend self
 
+    TEMPLATE_DIR = "#{CONFIG_DIR}/templates"
+
     def make_config_dir
       Dir.mkdir_p(CONFIG_DIR)
+    end
+
+    def make_templates
+      Dir.mkdir_p(TEMPLATE_DIR)
+      make_empty_template("comment.txt")
+      make_attachment_template
+      make_new_card_template
     end
 
     def display_intro_text
@@ -139,6 +149,21 @@ class App
 
     def write_config(token, member_id)
       File.write("#{App::CONFIG_DIR}/secrets.json", "{\"token\": \"#{token}\", \"memberId\": \"#{member_id}\"}")
+    end
+
+    def make_empty_template(template_name)
+      content = "\n\n#{Editor::COMMENT_STRING} Lines that start with a #{Editor::COMMENT_STRING} will not be included"
+      File.write("#{TEMPLATE_DIR}/#{template_name}", content)
+    end
+
+    def make_attachment_template
+      content = "#{Editor::COMMENT_STRING} CARD ATTACHMENT\n{\n  \"name\": \"\",\n  \"url\": \"\"\n}\n\n#{Editor::COMMENT_STRING} Lines that start with a #{Editor::COMMENT_STRING} will not be included"
+      File.write("#{TEMPLATE_DIR}/attachment.json", content)
+    end
+
+    def make_new_card_template
+      content = "#{Editor::COMMENT_STRING} NEW CARD\n{\n  \"name\": \"\",\n  \"description\": \"\"\n}\n\n#{Editor::COMMENT_STRING} Lines that start with a #{Editor::COMMENT_STRING} will not be included"
+      File.write("#{TEMPLATE_DIR}/new_card.json", content)
     end
   end
 end

--- a/src/app.cr
+++ b/src/app.cr
@@ -152,18 +152,37 @@ class App
     end
 
     def make_empty_template(template_name)
-      content = "\n\n#{Editor::COMMENT_STRING} Lines that start with a #{Editor::COMMENT_STRING} will not be included"
-      File.write("#{TEMPLATE_DIR}/#{template_name}", content)
+      File.write("#{TEMPLATE_DIR}/#{template_name}", "\n\n#{ignored_comments_declaration}")
     end
 
     def make_attachment_template
-      content = "#{Editor::COMMENT_STRING} CARD ATTACHMENT\n{\n  \"name\": \"\",\n  \"url\": \"\"\n}\n\n#{Editor::COMMENT_STRING} Lines that start with a #{Editor::COMMENT_STRING} will not be included"
+      content = <<-ATT
+      {
+        "name": "",
+        "url": ""
+      }
+
+      #{Editor::COMMENT_STRING} CARD ATTACHMENT
+      #{ignored_comments_declaration}
+      ATT
       File.write("#{TEMPLATE_DIR}/attachment.json", content)
     end
 
     def make_new_card_template
-      content = "#{Editor::COMMENT_STRING} NEW CARD\n{\n  \"name\": \"\",\n  \"description\": \"\"\n}\n\n#{Editor::COMMENT_STRING} Lines that start with a #{Editor::COMMENT_STRING} will not be included"
+      content = <<-CARD
+      {
+        "name": "",
+        "description": ""
+      }
+
+      #{Editor::COMMENT_STRING} NEW CARD
+      #{ignored_comments_declaration}
+      CARD
       File.write("#{TEMPLATE_DIR}/new_card.json", content)
+    end
+
+    def ignored_comments_declaration
+      "// Lines that start with `//` will be ignored."
     end
   end
 end

--- a/src/card_detail.cr
+++ b/src/card_detail.cr
@@ -93,7 +93,7 @@ class CardDetail
   end
 
   def add_comment
-    Editor.run do |comment|
+    Editor.run(template: "comment.txt") do |comment|
       API.post("/cards/#{@id}/actions/comments", form: { "text" => comment })
       fetch
     end
@@ -109,7 +109,7 @@ class CardDetail
   end
 
   def add_attachment
-    Editor.run(contents: "{\n  \"name\": \"\",\n  \"url\": \"\"\n}") do |json|
+    Editor.run(template: "attachment.json") do |json|
       att = JSON.parse(json)
       API.post("/cards/#{@id}/attachments", form: "name=#{att["name"]}&url=#{att["url"]}")
       fetch

--- a/src/cards_window.cr
+++ b/src/cards_window.cr
@@ -53,14 +53,7 @@ class CardsWindow < OptionSelectWindow
   def handle_key(key)
     case key
     when 'c'
-      contents = JSON.build do |json|
-        json.object do
-          json.field "name", ""
-          json.field "description", ""
-        end
-      end
-
-      Editor.run(contents: contents) do |card_json|
+      Editor.run(template: "new_card.json") do |card_json|
         card = JSON.parse(card_json)
         API.post("/cards", params: "idList=#{@list_id}", form: "name=#{card["name"]}&desc=#{card["description"]}")
         fetch

--- a/src/editor.cr
+++ b/src/editor.cr
@@ -3,12 +3,14 @@ require "./app"
 
 class Editor
   TEMP_FILE_PATH = "#{App::CONFIG_DIR}/trello.tmp"
+  TEMPLATES_PATH = "#{App::CONFIG_DIR}/templates"
+  COMMENT_STRING = "//"
 
-  def self.run(contents : String = "", &block)
+  def self.run(template : (String | Nil) = nil, &block)
     clear_temp_file
 
-    unless contents.empty?
-      File.write(TEMP_FILE_PATH, contents)
+    if template
+      copy_template_file(template)
     end
 
     Process.run(ENV["EDITOR"], args: {TEMP_FILE_PATH}, output: STDOUT, input: STDIN, error: STDERR, shell: true)
@@ -16,12 +18,25 @@ class Editor
     App.reset_screen
 
     unless !File.exists?(TEMP_FILE_PATH) || File.empty?(TEMP_FILE_PATH)
-      content = File.read(TEMP_FILE_PATH)
+      content = File.read(TEMP_FILE_PATH).chomp
+      content = strip_comments(content)
       yield content
     end
   end
 
   def self.clear_temp_file
     File.delete(TEMP_FILE_PATH) if File.exists?(TEMP_FILE_PATH)
+  end
+
+  def self.copy_template_file(template_file)
+    full_path = "#{TEMPLATES_PATH}/#{template_file}"
+    unless !File.exists?(full_path) || File.empty?(full_path)
+      content = File.read(full_path)
+      File.write(TEMP_FILE_PATH, content)
+    end
+  end
+
+  def self.strip_comments(content)
+    content.split("\n").reject { |l| l.starts_with?(COMMENT_STRING) }.join("\n").chomp
   end
 end

--- a/src/trello.cr
+++ b/src/trello.cr
@@ -1,6 +1,5 @@
-# TODO: Write documentation for `Trello`
-
 require "ncurses"
+require "option_parser"
 require "./*"
 
 module Trello
@@ -44,6 +43,11 @@ end
 unless ENV.fetch("CRYSTAL_ENV", nil) == "test"
   if !File.exists?("#{App::CONFIG_DIR}/secrets.json")
     App.run_setup
+  end
+
+  OptionParser.parse! do |parser|
+    parser.banner = "trello\n\nUsage: trello [arguments]"
+    parser.on("--setup-templates", "Set up editor templates") { App::Setup.make_templates; exit }
   end
 
   App.init


### PR DESCRIPTION
This idea came up as I've been writing comments. There are many times when I cannot remember a teammate's username in order to `@` them in a comment. This way, I can create a template for myself with a list of users as a reminder. Other users (are there any other users?) can do the same with whatever they'd like in their template whether that's in a comments area or as an actual template for content submission.

Since templates were previously not available if someone run the initial setup, I've added a `--setup-templates` flag to run on startup that will create the files. I might rewrite this in the future to not overwrite any templates that already exist so as to not overwrite any customizations.