### PR TITLE
feat: Support displaying and managing notifications

### DIFF
--- a/src/api.cr
+++ b/src/api.cr
@@ -19,7 +19,7 @@ class API
     response = HTTP::Client.post(url, form: form)
   end
 
-  def self.put(path : String, params : String)
+  def self.put(path : String, params : String = "")
     url = "#{API_ROOT}/#{path}?#{App.credentials}&#{params}"
     App.log.debug("PUTting URL: #{url}")
     response = HTTP::Client.put(url)

--- a/src/api.cr
+++ b/src/api.cr
@@ -5,7 +5,7 @@ require "./app"
 class API
   API_ROOT = "https://api.trello.com/1/"
 
-  def self.get(path : String, params : String)
+  def self.get(path : String, params : String = "")
     url = "#{API_ROOT}/#{path}?#{App.credentials}&#{params}"
     App.log.debug("GETting URL: #{url}")
     response = HTTP::Client.get(url)

--- a/src/app.cr
+++ b/src/app.cr
@@ -10,7 +10,7 @@ class App
   @@secrets : JSON::Any = JSON::Any.new("{}")
   @@token : String | Nil = ""
   @@log : Logger = Logger.new(nil)
-  @@notifications : Hash(String, Notification) = {} of String => Notification
+  @@notifications : Hash(String, Array(Notification)) = {} of String => Array(Notification)
 
   def self.init
     @@secrets = JSON.parse(File.read("#{CONFIG_DIR}/secrets.json"))
@@ -54,7 +54,7 @@ class App
     @@windows
   end
 
-  def self.notifications=(notifications : Hash(String, Notification))
+  def self.notifications=(notifications : Hash(String, Array(Notification)))
     @@notifications = notifications
   end
 

--- a/src/app.cr
+++ b/src/app.cr
@@ -10,6 +10,7 @@ class App
   @@secrets : JSON::Any = JSON::Any.new("{}")
   @@token : String | Nil = ""
   @@log : Logger = Logger.new(nil)
+  @@notifications : Hash(String, Notification) = {} of String => Notification
 
   def self.init
     @@secrets = JSON.parse(File.read("#{CONFIG_DIR}/secrets.json"))
@@ -51,6 +52,14 @@ class App
 
   def self.windows
     @@windows
+  end
+
+  def self.notifications=(notifications : Hash(String, Notification))
+    @@notifications = notifications
+  end
+
+  def self.notifications
+    @@notifications
   end
 
   def self.credentials
@@ -107,6 +116,10 @@ class App
     def yellow
       NCurses::ColorPair.new(4).init(NCurses::Color::YELLOW, NCurses::Color::BLACK).attr
     end
+
+    def red
+      NCurses::ColorPair.new(5).init(NCurses::Color::RED, NCurses::Color::BLACK).attr
+    end
   end
 
   module Setup
@@ -136,7 +149,7 @@ class App
     end
 
     def get_token
-      `open 'https://trello.com/1/authorize?expiration=never&scope=read,write&response_type=token&name=trello-cli&key=#{APP_KEY}'`
+      `open 'https://trello.com/1/authorize?expiration=never&scope=read,write,account&response_type=token&name=trello-cli&key=#{APP_KEY}'`
       print "Token: "
       gets
     end

--- a/src/cards_window.cr
+++ b/src/cards_window.cr
@@ -24,11 +24,14 @@ class CardsWindow < OptionSelectWindow
 
   def render_row(option)
     member_ids = option.json.as_h["members"].as_a.map { |m| m["id"].to_s }
+    notification = App.notifications[option.json.as_h["id"]]?
     if member_ids.includes?(App.member_id)
       win.attron(App::Colors.yellow)
+      notification.render(win) if notification
       super
       win.attroff(App::Colors.yellow)
     else
+      notification.render(win) if notification
       super
     end
   end

--- a/src/cards_window.cr
+++ b/src/cards_window.cr
@@ -38,6 +38,7 @@ class CardsWindow < OptionSelectWindow
 
   def handle_select_next(selected)
     card = CardDetail.new(id: selected.key, name: selected.value)
+    Notification.mark_read_for_card(card)
 
     details = DetailsWindow.new(card: card)
     details.link_parent(self)

--- a/src/cards_window.cr
+++ b/src/cards_window.cr
@@ -27,11 +27,11 @@ class CardsWindow < OptionSelectWindow
     notification = App.notifications[option.json.as_h["id"]]?
     if member_ids.includes?(App.member_id)
       win.attron(App::Colors.yellow)
-      notification.render(win) if notification
+      Notification.render(win) if notification
       super
       win.attroff(App::Colors.yellow)
     else
-      notification.render(win) if notification
+      Notification.render(win) if notification
       super
     end
   end

--- a/src/notification.cr
+++ b/src/notification.cr
@@ -1,0 +1,43 @@
+require "./api"
+require "./app"
+
+class Notification
+  SYMBOL = "🔔"
+
+  def initialize(@data : JSON::Any)
+  end
+
+  def card_id
+    return "" unless @data["data"]?
+    return "" unless @data["data"]["card"]?
+    @data["data"]["card"]["id"].to_s
+  end
+
+  def unread?
+    @data["unread"].as_bool
+  end
+
+  def render(win)
+    win.addstr(SYMBOL)
+    win.addstr(" ")
+  end
+
+  def self.fetch
+    json = API.get("members/me/notifications", "read_filter=unread&limit=1000")
+    App.notifications = json.as_a.each_with_object({} of String => Notification) do |notification, hash|
+      n = Notification.new(notification)
+      hash[n.card_id] = n unless n.card_id.blank?
+    end
+  end
+
+  def self.fetch_async
+    spawn do
+      json = API.get("members/me/notifications", "read_filter=unread&limit=1000")
+      App.notifications = json.as_a.each_with_object({} of String => Notification) do |notification, hash|
+        n = Notification.new(notification)
+        hash[n.card_id] = n unless n.card_id.blank?
+      end
+    end
+    Fiber.yield
+  end
+end

--- a/src/option_select_window.cr
+++ b/src/option_select_window.cr
@@ -50,9 +50,9 @@ class OptionSelectWindow < Window
 
       if i == @selected
         if @active
-          win.attron( App::Colors.blue | NCurses::Attribute::REVERSE)
+          win.attron(App::Colors.blue | NCurses::Attribute::REVERSE)
         else
-          win.attron( App::Colors.blue)
+          win.attron(App::Colors.blue)
         end
       end
       render_row(option)

--- a/src/option_select_window.cr
+++ b/src/option_select_window.cr
@@ -126,6 +126,7 @@ class OptionSelectWindow < Window
   def handle_select_previous
     @options = [] of OptionSelectOption
     @selected = 0
+    Notification.fetch_async
     activate_parent!
   end
 

--- a/src/trello.cr
+++ b/src/trello.cr
@@ -49,6 +49,7 @@ unless ENV.fetch("CRYSTAL_ENV", nil) == "test"
 
   OptionParser.parse! do |parser|
     parser.banner = "trello\n\nUsage: trello [arguments]"
+    parser.on("--setup", "Before starting, run through the setup process again") { App.run_setup }
     parser.on("--setup-templates", "Set up editor templates") { App::Setup.make_templates; exit }
   end
 

--- a/src/trello.cr
+++ b/src/trello.cr
@@ -24,6 +24,8 @@ module Trello
       NCurses.refresh
       App.windows.each { |w| w.refresh }
 
+      Notification.fetch_async
+
       while true
         NCurses.notimeout(true)
         key = NCurses.getch


### PR DESCRIPTION
Display a 🔔 on cards that have associated unread notifications. Once the card's detail is brought up, the notification(s) is/are cleared both locally and on Trello.

This level of interaction with Trello requires the `account` level access scope. Because of this, existing users may have to reauthorize the application in order to mark the notifications as read. For this reason, I've additionally added a `--setup` flag to the command line options to re-write the config file.

![cli](https://user-images.githubusercontent.com/385726/46751722-3147e980-cc70-11e8-9ec7-59a4e7236158.gif)
