### PR TITLE
feat(Cards): Allow configuration to display card labels

### DIFF
--- a/src/app.cr
+++ b/src/app.cr
@@ -9,6 +9,7 @@ class App
   @@member_id : String = ""
   @@secrets : JSON::Any = JSON::Any.new("{}")
   @@token : String | Nil = ""
+  @@card_labels : Hash(String, String) = {} of String => String
   @@log : Logger = Logger.new(nil)
   @@notifications : Hash(String, Array(Notification)) = {} of String => Array(Notification)
 
@@ -16,6 +17,10 @@ class App
     @@secrets = JSON.parse(File.read("#{CONFIG_DIR}/secrets.json"))
     @@token = App.secrets["token"].to_s
     @@member_id = @@secrets["memberId"].to_s
+    @@secrets.as_h.has_key?("cardLabels") && @@secrets["cardLabels"].as_h
+      .each do |k, v|
+        @@card_labels[k.to_s] = v.to_s
+      end
     @@log = Logger.new(File.open("#{CONFIG_DIR}/log.txt", "w"), level: Logger::DEBUG)
   end
 
@@ -76,6 +81,10 @@ class App
 
   def self.log
     @@log
+  end
+
+  def self.card_labels
+    @@card_labels
   end
 
   def self.run_setup
@@ -161,7 +170,15 @@ class App
     end
 
     def write_config(token, member_id)
-      File.write("#{App::CONFIG_DIR}/secrets.json", "{\"token\": \"#{token}\", \"memberId\": \"#{member_id}\"}")
+      content = <<-CONFIG
+      {
+        "token": "#{token}",
+        "memberId": "#{member_id}",
+        "cardLabels": {
+        }
+      }
+      CONFIG
+      File.write("#{App::CONFIG_DIR}/secrets.json", content)
     end
 
     def make_empty_template(template_name)
@@ -195,7 +212,7 @@ class App
     end
 
     def ignored_comments_declaration
-      "// Lines that start with `//` will be ignored."
+      "#{Editor::COMMENT_STRING} Lines that start with `#{Editor::COMMENT_STRING}` will be ignored."
     end
   end
 end

--- a/src/cards_window.cr
+++ b/src/cards_window.cr
@@ -1,5 +1,6 @@
 require "./option_select_window"
 require "./card_detail"
+require "./label_renderer"
 
 class CardsWindow < OptionSelectWindow
   property list_id : String = ""
@@ -19,19 +20,22 @@ class CardsWindow < OptionSelectWindow
   def set_list_id(id : String)
     @list_id = id
     @path = "lists/#{id}/cards"
-    @params = "fields=name,shortUrl&members=true"
+    @params = "fields=name,shortUrl,labels&members=true"
   end
 
   def render_row(option)
     member_ids = option.json.as_h["members"].as_a.map { |m| m["id"].to_s }
     notification = App.notifications[option.json.as_h["id"]]?
+    labels = option.json.as_h["labels"].as_a.map { |l| l["name"].to_s }
     if member_ids.includes?(App.member_id)
       win.attron(App::Colors.yellow)
       Notification.render(win) if notification
+      LabelRenderer.render(win, labels)
       super
       win.attroff(App::Colors.yellow)
     else
       Notification.render(win) if notification
+      LabelRenderer.render(win, labels)
       super
     end
   end

--- a/src/label_renderer.cr
+++ b/src/label_renderer.cr
@@ -1,0 +1,11 @@
+require "./app"
+
+class LabelRenderer
+  def self.render(win, labels)
+    labels.each do |label|
+      if App.card_labels[label]?
+        win.addstr(App.card_labels[label])
+      end
+    end
+  end
+end


### PR DESCRIPTION
If you add a label referenced by its name to secrets.json, the app
will display the configured string in front of a card name in the
cards list. For example, I have this in my secrets.json:

```
{
  "token": "mySecretToken",
  "memberId": "mySecretId",
  "cardLabels": {
    "Blocked": "[BLOCKED] ",
    "Zendesk": "[ZD] "
  }
}
```

When a card is listed that has either of those label names, it will
display the configured string:

```
[ZD] [BLOCKED] #32435 A customer request
```

You could also use emojis if your terminal allows.

![screenshot 2018-11-30 10 48 34](https://user-images.githubusercontent.com/385726/49309119-04a19880-f48f-11e8-8f17-f9545f8ec9f9.png)
