### PR TITLE
Fix build on newer versions of Crystal

### DIFF
--- a/src/attachment_select_window.cr
+++ b/src/attachment_select_window.cr
@@ -4,7 +4,7 @@ class AttachmentSelectWindow < OptionSelectWindow
   property on_select : (String -> IO) | (String -> Nil) = ->(list_id : String) {}
 
   def initialize(@card_id : String, &block)
-    super(x: NCurses.maxx / 4, y: NCurses.maxy / 4, height: NCurses.maxy / 2, width: NCurses.maxx / 2) do |win|
+    super(x: NCurses.maxx // 4, y: NCurses.maxy // 4, height: NCurses.maxy // 2, width: NCurses.maxx // 2) do |win|
       win.title = "Attachments"
       win.path = "cards/#{@card_id}/attachments"
       App.add_window(win)

--- a/src/help_window.cr
+++ b/src/help_window.cr
@@ -5,7 +5,7 @@ class HelpWindow < Window
   property helps : Array(NamedTuple(key: String, description: String)) = [] of NamedTuple(key: String, description: String)
 
   def initialize(&block)
-    initialize(x: NCurses.maxx / 4, y: NCurses.maxy / 4, height: NCurses.maxy / 2, width: NCurses.maxx / 2) do |win|
+    initialize(x: NCurses.maxx // 4, y: NCurses.maxy // 4, height: NCurses.maxy // 2, width: NCurses.maxx // 2) do |win|
       win.title = "Help"
       win.active = true
       yield win

--- a/src/label_select_window.cr
+++ b/src/label_select_window.cr
@@ -5,7 +5,7 @@ class LabelSelectWindow < OptionSelectWindow
   # @on_select : String -> IO) = ->(label_id : String) {}
 
   def initialize(@board_id : String, &block)
-    super(x: NCurses.maxx / 4, y: NCurses.maxy / 4, width: NCurses.maxx / 2, height: NCurses.maxy / 2) do |win|
+    super(x: NCurses.maxx // 4, y: NCurses.maxy // 4, width: NCurses.maxx // 2, height: NCurses.maxy // 2) do |win|
       win.title = "Available Labels"
       win.path = "boards/#{@board_id}/labels"
       App.add_window(win)

--- a/src/list_select_window.cr
+++ b/src/list_select_window.cr
@@ -2,7 +2,7 @@ class ListSelectWindow < OptionSelectWindow
   property on_select : (String -> IO) | (String -> Nil) = ->(list_id : String) {}
 
   def initialize(@board_id : String, &block)
-    super(x: NCurses.maxx / 4, y: NCurses.maxy / 4, width: NCurses.maxx / 2, height: NCurses.maxy / 2) do |win|
+    super(x: NCurses.maxx // 4, y: NCurses.maxy // 4, width: NCurses.maxx // 2, height: NCurses.maxy // 2) do |win|
       win.title = "Available Lists"
       win.path = "boards/#{@board_id}/lists"
       App.add_window(win)

--- a/src/popup.cr
+++ b/src/popup.cr
@@ -8,7 +8,7 @@ class Popup < Window
   property on_close : Proc(Void) = -> {}
   property text : String = ""
 
-  def initialize(x = NCurses.maxx / 4, y = NCurses.maxy / 4, height = NCurses.maxy / 2, width = NCurses.maxx / 2, &block)
+  def initialize(x = NCurses.maxx // 4, y = NCurses.maxy // 4, height = NCurses.maxy // 2, width = NCurses.maxx // 2, &block)
     initialize(x: x, y: y, height: height, width: width) do |win|
       win.active = true
       yield win


### PR DESCRIPTION
On Crystal 0.31+ the `/` operator on ints always returns floats.
ncurses expects to be passed integers to define coordinates and sizes,
so we need to use integer division instead, with operator `//`.